### PR TITLE
Fix AWS Amplify deployment trace file errors

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -8,20 +8,26 @@ frontend:
       commands:
         - echo "Verifying assets"
         - bash scripts/copy-missing-assets.sh
-        - ls -la public/images/about/
+        - echo "Creating trace files before build"
+        - bash scripts/create-trace-files.sh
         - echo "Building Next.js application in SSR mode"
         - export NODE_OPTIONS="--max-old-space-size=4096"
         - npm run build
         - echo "Running post-build script for SSR deployment"
         - bash scripts/amplify-postbuild.sh
+        - echo "Creating trace files after build"
+        - bash scripts/create-trace-files.sh
   artifacts:
     baseDirectory: .
     files:
       - '**/*'
+      - '.next/trace/**/*'
+      - 'trace/**/*'
+      - 'required-server-files.json'
+      - 'server.js'
     discard:
       - 'node_modules/**/*'
       - '.git/**/*'
-      - 'src/**/*'
       - '.next/cache/**/*'
   cache:
     paths:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --no-lint",
+    "build": "next build --no-lint && node scripts/fix-trace-files.js",
     "start": "next start",
     "lint": "next lint"
   },

--- a/scripts/amplify-postbuild.sh
+++ b/scripts/amplify-postbuild.sh
@@ -21,9 +21,21 @@ if [ -d ".next/standalone" ]; then
   fi
   
   # Ensure trace files are available for Amplify
+  # Remove existing trace file if it's not a directory
+  if [ -e ".next/trace" ] && [ ! -d ".next/trace" ]; then
+    rm -f .next/trace
+    echo "Removed existing trace file"
+  fi
+  
+  # Create trace directory
   mkdir -p .next/trace
   touch .next/trace/.trace
   echo "Created trace directory and placeholder file"
+  
+  # Create additional trace files at the root directory
+  mkdir -p trace
+  touch trace/.trace
+  echo "Created root trace directory and placeholder file"
   
   # Verify the directory structure
   echo "Root directory contents:"

--- a/scripts/create-trace-files.sh
+++ b/scripts/create-trace-files.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo "Creating trace files specifically for AWS Amplify deployment..."
+
+# Create root trace directory and file
+mkdir -p trace
+touch trace/.trace
+echo "Created trace directory and file at project root"
+
+# Create .next/trace directory and file
+if [ -e ".next/trace" ] && [ ! -d ".next/trace" ]; then
+  echo "Found .next/trace as a file, removing it..."
+  rm -f .next/trace
+fi
+
+mkdir -p .next/trace
+touch .next/trace/.trace
+echo "Created trace directory and file in .next directory"
+
+# Create trace directory at the expected Amplify location
+mkdir -p /codebuild/output/src*/src/indowagen/trace
+touch /codebuild/output/src*/src/indowagen/trace/.trace
+echo "Created trace directory and file at Amplify build output location"
+
+echo "Trace files setup complete!"
+
+# List the created directories to verify
+echo "Listing trace directories:"
+ls -la trace
+ls -la .next/trace
+ls -la /codebuild/output/src*/src/indowagen/trace || echo "Not running in Amplify environment"

--- a/scripts/fix-trace-files.js
+++ b/scripts/fix-trace-files.js
@@ -1,0 +1,45 @@
+// This script creates the trace files AWS Amplify expects
+const fs = require('fs');
+const path = require('path');
+
+// Create a .next/trace directory and a placeholder file within it
+const traceDir = path.join(process.cwd(), '.next', 'trace');
+
+if (!fs.existsSync(traceDir)) {
+  try {
+    fs.mkdirSync(traceDir, { recursive: true });
+    console.log('Created trace directory at', traceDir);
+  } catch (err) {
+    console.error('Error creating trace directory:', err.message);
+  }
+}
+
+// Create an empty file named .trace in the trace directory
+const traceFile = path.join(traceDir, '.trace');
+try {
+  fs.writeFileSync(traceFile, '');
+  console.log('Created empty trace file at', traceFile);
+} catch (err) {
+  console.error('Error creating trace file:', err.message);
+}
+
+// For Amplify, duplicate the trace directory at the root as well
+const rootTraceDir = path.join(process.cwd(), 'trace');
+if (!fs.existsSync(rootTraceDir)) {
+  try {
+    fs.mkdirSync(rootTraceDir, { recursive: true });
+    console.log('Created root trace directory at', rootTraceDir);
+  } catch (err) {
+    console.error('Error creating root trace directory:', err.message);
+  }
+}
+
+const rootTraceFile = path.join(rootTraceDir, '.trace');
+try {
+  fs.writeFileSync(rootTraceFile, '');
+  console.log('Created empty root trace file at', rootTraceFile);
+} catch (err) {
+  console.error('Error creating root trace file:', err.message);
+}
+
+console.log('Trace files setup completed successfully!');


### PR DESCRIPTION
- Add dedicated trace file creation scripts (create-trace-files.sh and fix-trace-files.js)
- Update build process to ensure trace files exist before and after build
- Fix post-build script to handle non-directory trace paths
- Explicitly include trace files in Amplify artifacts
- Fix path handling for AWS Amplify build environment